### PR TITLE
feat: add theme creation, pass prop

### DIFF
--- a/.changeset/module-theme-objects.md
+++ b/.changeset/module-theme-objects.md
@@ -1,0 +1,9 @@
+---
+"@dateforge/react-calendar": minor
+---
+
+Per-module theming, completed.
+
+- **`theme` on any module now takes a `createTheme` object**, not just a built-in family name — the same `string | ThemeFamily` union as the root `<Calendar theme>`. A name still rides on `data-theme`; an object is applied as inline `--c-*` vars with `light-dark()` values, so a custom family flips with the active scheme without any JS. Works on every module, including the tracks (`CalendarDaysTrack` / `CalendarMonthsTrack` / `CalendarYearsTrack`). The union is exported as `ModuleTheme`.
+- **Fixed: per-module `scheme` painted nothing.** The attribute rendered, but only the root shell and portalled popups narrowed `color-scheme`, so every `light-dark()` token inside a module resolved to the light side regardless of the module's `scheme`. Module-level `data-scheme` now narrows `color-scheme` too (`auto` re-opens both sides).
+- A module that declares its own `theme` or `scheme` now paints its own surface (`background: var(--c-backdrop)`; modules without either stay transparent and inherit the root) — otherwise a dark-schemed module painted light ink onto the root's light backdrop.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -361,8 +361,27 @@ All modules are importable from the `/modules` barrel or (preferably) their own 
 
 - `col?: number | string` — placement in the root grid.
 - `className?: string` — extra class on the module container.
-- `theme?: string` — per-module theme override (a built-in **name**; `data-theme` on the container). Custom token objects are root-only.
-- `scheme?: "light" | "dark" | "auto"` — per-module scheme override.
+- `theme?: string | ThemeFamily` — per-module theme override. A built-in **name** rides on `data-theme`; a **`createTheme` object** is applied as inline `--c-*` vars (`light-dark()` values) on the container — the same union the root `theme` takes.
+- `scheme?: "light" | "dark" | "auto"` — per-module scheme override; narrows `color-scheme` on the module, so `light-dark()` tokens resolve to that side.
+- A module that sets `theme` or `scheme` becomes its own painted surface (`background: var(--c-backdrop)`), so a dark-schemed module stays readable inside a light root. Modules without either stay transparent and inherit the root.
+
+```tsx
+import { createTheme } from "@dateforge/react-calendar";
+
+const brand = createTheme({
+  accent: "#7c5cff",
+  light: { backdrop: "#f7f5ff", text: "#241a4d" },
+  dark: { backdrop: "#161029", text: "#e6e0ff" },
+});
+
+<Calendar config={config}>
+  <CalendarToolbar />
+  <CalendarDays theme="espresso" />        {/* built-in name */}
+  <CalendarPresets theme={brand} scheme="dark" />  {/* token object */}
+</Calendar>;
+```
+
+Note: a module theme does NOT reach that module's portalled popup — popups re-declare the ROOT theme/scheme (they render into `<body>`, outside the module).
 - Per-module `on*Select` callbacks are **observational** — the root `onChange` remains the single source of the public value.
 - aria strings resolve `module prop → root labels → English default` (see [Localization](#localization)).
 
@@ -1022,6 +1041,7 @@ The library uses zero `!important`, so plain (unlayered) user CSS also wins by d
 |---|---|
 | Root shell | `data-dateforge-root`, plus `data-theme`, `data-appearance`, `data-scheme`, `data-gradient`, `data-readonly` |
 | Popups (portalled to `<body>`) | `data-dateforge-popup` (re-declares theme/scheme/appearance) |
+| Any module with `theme`/`scheme` | `data-theme` (built-in name) or inline `--c-*` vars (token object), `data-scheme`; both narrow `color-scheme` and paint `--c-backdrop` |
 | Day grid | `data-dateforge-days`, header cells `data-weekday` (+`data-weekend`), option flags `data-week-numbers`, `data-weekend-tint`, `data-weekend-headers`, `data-bold-weekends`, `data-today-dot`, `data-today-outline` |
 | Day cells | `data-date="YYYYMMDD"` + the [flag contract](#day-cell-data--contract) |
 | Toolbar | `data-dateforge-toolbar`; parts: `data-toolbar-prev/next/home/label/month-label/year-label/day-label/month-trigger/year-trigger/clear/apply/clock/time/theme-toggle` |

--- a/src/__tests__/react/module-theme.test.tsx
+++ b/src/__tests__/react/module-theme.test.tsx
@@ -1,0 +1,101 @@
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { presetToday } from "@/core/preset-engine";
+import { CalendarDays } from "@/modules/days/CalendarDays";
+import { CalendarPresets } from "@/modules/presets/CalendarPresets";
+import { CalendarToolbar } from "@/modules/toolbar/CalendarToolbar";
+import { CalendarYearsTrack } from "@/modules/years-track/CalendarYearsTrack";
+import { Calendar } from "@/react/calendar";
+import { createTheme } from "@/styles/theme-tokens";
+import { buildConfig, D } from "../fixtures/builders";
+
+const family = createTheme({
+  accent: "#14b8a6",
+  light: { backdrop: "#ffffff" },
+  dark: { backdrop: "#111111" },
+});
+
+function setup(ui: ReactNode) {
+  return render(
+    <Calendar
+      config={buildConfig({ mode: "single" })}
+      initialView={D(2026, 6, 1)}
+    >
+      {ui}
+    </Calendar>,
+  );
+}
+
+const days = (c: HTMLElement) =>
+  c.querySelector<HTMLElement>("[data-dateforge-days]");
+
+describe("per-module theme", () => {
+  it("a built-in name rides on data-theme, with no inline vars", () => {
+    const { container } = setup(<CalendarDays theme="meadow" />);
+    const grid = days(container);
+    expect(grid?.getAttribute("data-theme")).toBe("meadow");
+    expect(grid?.style.getPropertyValue("--c-accent")).toBe("");
+  });
+
+  it("a createTheme object becomes inline light-dark vars (no data-theme)", () => {
+    const { container } = setup(<CalendarDays theme={family} />);
+    const grid = days(container);
+    expect(grid?.getAttribute("data-theme")).toBeNull();
+    expect(grid?.style.getPropertyValue("--c-accent")).toBe("#14b8a6");
+    expect(grid?.style.getPropertyValue("--c-backdrop")).toBe(
+      "light-dark(#ffffff, #111111)",
+    );
+  });
+
+  it("theme vars never displace the module's own layout vars", () => {
+    const { container } = setup(<CalendarDays theme={family} col={2} />);
+    const grid = days(container);
+    // Weekend strip vars and the grid slot are written after the theme spread.
+    expect(grid?.style.getPropertyValue("--wknd-a-start")).not.toBe("");
+    expect(grid?.style.gridColumn).toBeTruthy();
+  });
+
+  it("works on a non-Days module (presets container)", () => {
+    const { container } = setup(
+      <CalendarPresets theme={family} presets={[presetToday]} />,
+    );
+    const el = container.querySelector<HTMLElement>("[data-dateforge-presets]");
+    expect(el?.style.getPropertyValue("--c-accent")).toBe("#14b8a6");
+  });
+
+  it("works on the toolbar container", () => {
+    const { container } = setup(<CalendarToolbar theme={family} />);
+    const el = container.querySelector<HTMLElement>("[data-dateforge-toolbar]");
+    expect(el?.style.getPropertyValue("--c-accent")).toBe("#14b8a6");
+  });
+
+  it("works on tracks (VirtualTrack container)", () => {
+    const { container } = setup(
+      <CalendarYearsTrack theme={family} minYear={2020} maxYear={2030} />,
+    );
+    const el = container.querySelector<HTMLElement>(
+      "[data-area='years-track']",
+    );
+    expect(el?.getAttribute("data-theme")).toBeNull();
+    expect(el?.style.getPropertyValue("--c-accent")).toBe("#14b8a6");
+  });
+
+  it("tracks still take a built-in name on data-theme", () => {
+    const { container } = setup(
+      <CalendarYearsTrack theme="meadow" scheme="dark" />,
+    );
+    const el = container.querySelector<HTMLElement>(
+      "[data-area='years-track']",
+    );
+    expect(el?.getAttribute("data-theme")).toBe("meadow");
+    expect(el?.getAttribute("data-scheme")).toBe("dark");
+  });
+
+  it("no theme prop leaves the container untouched (inherits the root)", () => {
+    const { container } = setup(<CalendarDays />);
+    const grid = days(container);
+    expect(grid?.getAttribute("data-theme")).toBeNull();
+    expect(grid?.style.getPropertyValue("--c-accent")).toBe("");
+  });
+});

--- a/src/modules/days-track/CalendarDaysTrack.tsx
+++ b/src/modules/days-track/CalendarDaysTrack.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../core/calendar-date";
 import { CheckIcon, ClearIcon } from "../../react/icons";
 import { useLabels } from "../../react/labels-context";
+import type { ModuleTheme } from "../../react/module-theme";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { useStoreSelector } from "../../react/use-store-selector";
 import { VirtualTrack } from "../../react/VirtualTrack";
@@ -23,8 +24,11 @@ export type CalendarDaysTrackProps = {
   bound?: "from" | "to";
   col?: number | string;
   className?: string;
-  /** Per-module theme override (`data-theme` on the track). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the track).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the track). */
   scheme?: "light" | "dark" | "auto";
   onDaySelect?: (year: number, month: number, day: number) => void;

--- a/src/modules/days/CalendarDays.tsx
+++ b/src/modules/days/CalendarDays.tsx
@@ -21,6 +21,7 @@ import { today } from "../../core/timezone-boundary";
 import { usePageSlide } from "../../hooks/use-page-slide";
 import { dayDataAttrs } from "../../react/day-attrs";
 import { useLabels } from "../../react/labels-context";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { useStoreSelector } from "../../react/use-store-selector";
 import { getGridSlotStyle } from "../../utils/get-grid-slot-style";
@@ -113,8 +114,11 @@ export type CalendarDaysProps = {
    * or useCallback) — an inline closure re-renders all 42 cells every pass.
    */
   renderDay?: RenderDay;
-  /** Per-module theme override (`data-theme` on the module container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the module container). */
   scheme?: "light" | "dark" | "auto";
   col?: number | string;
@@ -236,6 +240,7 @@ export function CalendarDays({
   col,
   className,
 }: CalendarDaysProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
   const t = useLabels();
@@ -405,7 +410,7 @@ export function CalendarDays({
         new Date(shownDate.year, shownDate.month - 1, 1),
       )}
       data-dateforge-days=""
-      data-theme={theme}
+      data-theme={dataTheme}
       data-scheme={scheme}
       data-week-numbers={weekNumbers ? "" : undefined}
       data-weekend-tint={highlightWeekends ? "" : undefined}
@@ -416,6 +421,7 @@ export function CalendarDays({
       className={[styles.grid, className].filter(Boolean).join(" ")}
       style={
         {
+          ...themeStyle,
           ...getGridSlotStyle(col),
           "--wknd-a-start": weekendStrips.aStart,
           "--wknd-a-span": weekendStrips.aSpan,

--- a/src/modules/days/Days.stories.tsx
+++ b/src/modules/days/Days.stories.tsx
@@ -2,8 +2,16 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { buildConfig, D } from "../../__tests__/fixtures/builders";
 import type { CalendarDate } from "../../core/calendar-date";
 import { Calendar } from "../../react/calendar";
+import { createTheme } from "../../styles/theme-tokens";
 import { storyLocale, storyThemeProps } from "../_lab/story-globals";
 import { CalendarDays, type DayRenderState } from "./CalendarDays";
+
+/** A `createTheme` family handed straight to a module's `theme` prop. */
+const brandTheme = createTheme({
+  accent: "#7c5cff",
+  light: { backdrop: "#f7f5ff", text: "#241a4d", tone: "#ece7ff" },
+  dark: { backdrop: "#161029", text: "#e6e0ff", tone: "#241a4d" },
+});
 
 const meta: Meta = {
   title: "Days",
@@ -164,4 +172,49 @@ export const RenderDayPrices: Story = {
       <CalendarDays renderDay={priceDay} />
     </Calendar>
   ),
+};
+
+/**
+ * Per-module theming, both forms. The left grid takes a built-in family NAME
+ * (rides on `data-theme`); the right one takes a `createTheme` token OBJECT
+ * (inline `--c-*` vars, `light-dark()` values). A module that declares a theme
+ * or a `scheme` paints its own backdrop, so a dark-schemed module stays
+ * readable inside a light root.
+ */
+export const PerModuleTheme: Story = {
+  render: (_, ctx) => (
+    <div style={{ display: "grid", gap: 16, gridAutoFlow: "column" }}>
+      <Calendar
+        {...storyThemeProps(ctx.globals)}
+        config={buildConfig({ ...storyLocale(ctx.globals), mode: "single" })}
+        initialView={D(2026, 6, 1)}
+      >
+        <CalendarDays theme="espresso" />
+      </Calendar>
+      <Calendar
+        {...storyThemeProps(ctx.globals)}
+        config={buildConfig({ ...storyLocale(ctx.globals), mode: "single" })}
+        initialView={D(2026, 6, 1)}
+      >
+        <CalendarDays theme={brandTheme} scheme="dark" />
+      </Calendar>
+    </div>
+  ),
+  // Cascade check — invisible to happy-dom, so it lives in the browser project:
+  // a module-level `scheme` must narrow `color-scheme` (otherwise every
+  // light-dark() token silently resolves to the light side) and the module must
+  // paint its own backdrop.
+  play: ({ canvasElement }) => {
+    const grids = canvasElement.querySelectorAll("[data-dateforge-days]");
+    const dark = grids[1] as HTMLElement;
+    const cs = getComputedStyle(dark);
+    if (cs.colorScheme !== "dark")
+      throw new Error(
+        `module scheme did not narrow color-scheme: ${cs.colorScheme}`,
+      );
+    if (cs.backgroundColor !== "rgb(22, 16, 41)")
+      throw new Error(
+        `module theme did not paint its backdrop: ${cs.backgroundColor}`,
+      );
+  },
 };

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -9,6 +9,8 @@
  */
 import "../styles/layers.css";
 
+// Every module's `theme` prop takes this union (built-in name or `createTheme`).
+export type { ModuleTheme } from "../react/module-theme";
 export { CalendarDays, type CalendarDaysProps } from "./days/CalendarDays";
 export {
   CalendarDaysTrack,

--- a/src/modules/info/CalendarInfo.tsx
+++ b/src/modules/info/CalendarInfo.tsx
@@ -6,6 +6,7 @@ import { today as getToday } from "../../core/timezone-boundary";
 import { useToday } from "../../hooks/use-today";
 import { ClearIcon, HomeIcon } from "../../react/icons";
 import { useLabels } from "../../react/labels-context";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { UIButton } from "../../react/ui/button";
 import { useStoreSelector } from "../../react/use-store-selector";
@@ -43,8 +44,11 @@ export type CalendarInfoProps = {
   clearLabel?: string;
   /** Override for the home action aria-label (registry key `home`). */
   homeLabel?: string;
-  /** Per-module theme override (`data-theme` on the module container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the module container). */
   scheme?: "light" | "dark" | "auto";
   col?: number | string;
@@ -122,6 +126,7 @@ export function CalendarInfo({
   col,
   className,
 }: CalendarInfoProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
   const t = useLabels();
@@ -279,10 +284,10 @@ export function CalendarInfo({
     <div
       data-dateforge-info=""
       data-area="calendar-info"
-      data-theme={theme}
+      data-theme={dataTheme}
       data-scheme={scheme}
       className={[styles.container, className].filter(Boolean).join(" ")}
-      style={getGridSlotStyle(col)}
+      style={{ ...themeStyle, ...getGridSlotStyle(col) }}
     >
       <div className={styles.inner}>
         <div

--- a/src/modules/lunar/CalendarLunar.tsx
+++ b/src/modules/lunar/CalendarLunar.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useLabels } from "../../react/labels-context";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import { useCalendarStore } from "../../react/provider";
 import { useStoreSelector } from "../../react/use-store-selector";
 import { getGridSlotStyle } from "../../utils/get-grid-slot-style";
@@ -36,8 +37,11 @@ export type CalendarLunarProps = {
   phaseLabels?: false | Partial<Record<LunarPhaseKey, string>>;
   /** Long phase names for per-cell aria. Override per locale. */
   phaseAriaLabels?: Partial<Record<LunarPhaseKey, string>>;
-  /** Per-module theme override (`data-theme` on the module container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the module container). */
   scheme?: "light" | "dark" | "auto";
   col?: number | string;
@@ -96,6 +100,7 @@ export function CalendarLunar({
   col,
   className,
 }: CalendarLunarProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
   const t = useLabels();
@@ -159,10 +164,10 @@ export function CalendarLunar({
     <div
       data-dateforge-lunar=""
       data-area="lunar"
-      data-theme={theme}
+      data-theme={dataTheme}
       data-scheme={scheme}
       className={[styles.container, className].filter(Boolean).join(" ")}
-      style={gridSlot}
+      style={{ ...themeStyle, ...gridSlot }}
     >
       <div
         className={styles.strip}

--- a/src/modules/manual-input/CalendarManualInput.tsx
+++ b/src/modules/manual-input/CalendarManualInput.tsx
@@ -12,6 +12,7 @@ import { compareDate } from "../../core/calendar-date";
 import { today as getToday } from "../../core/timezone-boundary";
 import { ClearIcon } from "../../react/icons";
 import { useLabels } from "../../react/labels-context";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { UIButton } from "../../react/ui/button";
 import { useStoreSelector } from "../../react/use-store-selector";
@@ -48,8 +49,11 @@ export type CalendarManualInputProps = {
   clearLabel?: string;
   /** Horizontal alignment of the row. Default "left". */
   align?: "left" | "center" | "right";
-  /** Per-module theme override (`data-theme` on the module container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the module container). */
   scheme?: "light" | "dark" | "auto";
   col?: number | string;
@@ -98,6 +102,7 @@ export function CalendarManualInput({
   col,
   className,
 }: CalendarManualInputProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
   const t = useLabels();
@@ -326,10 +331,11 @@ export function CalendarManualInput({
     <div
       data-dateforge-manual-input=""
       data-area="manual-input"
-      data-theme={theme}
+      data-theme={dataTheme}
       data-scheme={scheme}
       className={[styles.container, className].filter(Boolean).join(" ")}
       style={{
+        ...themeStyle,
         ...getGridSlotStyle(col),
         alignItems: ALIGN_TO_JUSTIFY[align],
       }}

--- a/src/modules/months-grid/CalendarMonthsGrid.tsx
+++ b/src/modules/months-grid/CalendarMonthsGrid.tsx
@@ -8,6 +8,7 @@ import { rangesOverlap } from "../../core/calendar-range";
 import type { DateRuleEngine } from "../../core/date-rule-engine";
 import { useRovingTileFocus } from "../../hooks/use-roving-tile-focus";
 import { useLabels } from "../../react/labels-context";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { UITile } from "../../react/ui/tile";
 import { useStoreSelector } from "../../react/use-store-selector";
@@ -30,8 +31,11 @@ export type CalendarMonthsGridProps = {
   outOfRangeBehavior?: OutOfRangeBehavior;
   col?: number | string;
   className?: string;
-  /** Per-module theme override (`data-theme` on the module container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the module container). */
   scheme?: "light" | "dark" | "auto";
   onMonthSelect?: (year: number, month: number) => void;
@@ -69,6 +73,7 @@ export function CalendarMonthsGrid({
   scheme,
   onMonthSelect,
 }: CalendarMonthsGridProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
   const t = useLabels();
@@ -145,10 +150,10 @@ export function CalendarMonthsGrid({
     <div
       data-dateforge-months-grid=""
       data-area="months"
-      data-theme={theme}
+      data-theme={dataTheme}
       data-scheme={scheme}
       className={[styles.container, className].filter(Boolean).join(" ")}
-      style={gridSlot}
+      style={{ ...themeStyle, ...gridSlot }}
     >
       <div
         ref={containerRef}

--- a/src/modules/months-track/CalendarMonthsTrack.tsx
+++ b/src/modules/months-track/CalendarMonthsTrack.tsx
@@ -2,6 +2,7 @@ import { type CSSProperties, useMemo } from "react";
 import { boundDateOf } from "../../core/bound";
 import { calendarDate, daysInMonth } from "../../core/calendar-date";
 import { useLabels } from "../../react/labels-context";
+import type { ModuleTheme } from "../../react/module-theme";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { useStoreSelector } from "../../react/use-store-selector";
 import { VirtualTrack } from "../../react/VirtualTrack";
@@ -15,8 +16,11 @@ export type CalendarMonthsTrackProps = {
   bound?: "from" | "to";
   col?: number | string;
   className?: string;
-  /** Per-module theme override (`data-theme` on the track). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the track).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the track). */
   scheme?: "light" | "dark" | "auto";
   onMonthSelect?: (year: number, month: number) => void;

--- a/src/modules/months-wheel/CalendarMonthsWheel.tsx
+++ b/src/modules/months-wheel/CalendarMonthsWheel.tsx
@@ -4,6 +4,7 @@ import { calendarDate, daysInMonth } from "../../core/calendar-date";
 import { toCalendarDateTime } from "../../core/timezone-boundary";
 import { useToday } from "../../hooks/use-today";
 import { useLabels } from "../../react/labels-context";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import { usePickerDraft } from "../../react/picker-draft";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { UIButton } from "../../react/ui/button";
@@ -55,8 +56,11 @@ export type CalendarMonthsWheelProps = {
    * drum (v2 parity). Hidden while the range is empty. Default `true`.
    */
   showBoundDate?: boolean;
-  /** Per-module theme override (`data-theme` on the module container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the module container). */
   scheme?: "light" | "dark" | "auto";
   col?: number | string;
@@ -81,6 +85,7 @@ export function CalendarMonthsWheel({
   className,
   onMonthSelect,
 }: CalendarMonthsWheelProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
   const t = useLabels();
@@ -166,10 +171,10 @@ export function CalendarMonthsWheel({
     <div
       data-dateforge-months-wheel=""
       data-area="months-wheel"
-      data-theme={theme}
+      data-theme={dataTheme}
       data-scheme={scheme}
       className={[styles.container, className].filter(Boolean).join(" ")}
-      style={gridSlot}
+      style={{ ...themeStyle, ...gridSlot }}
     >
       {headerText && (
         <div className={styles.boundedDate} data-bound={bound}>

--- a/src/modules/presets/CalendarPresets.tsx
+++ b/src/modules/presets/CalendarPresets.tsx
@@ -12,6 +12,7 @@ import {
 import type { SelectionState } from "../../core/state";
 import { today } from "../../core/timezone-boundary";
 import { useRovingTileFocus } from "../../hooks/use-roving-tile-focus";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { UITile } from "../../react/ui/tile";
 import { useStoreSelector } from "../../react/use-store-selector";
@@ -56,8 +57,11 @@ export type CalendarPresetsProps = {
   presets?: (Preset | PresetInput)[];
   col?: number | string;
   className?: string;
-  /** Per-module theme override (`data-theme` on the module container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the module container). */
   scheme?: "light" | "dark" | "auto";
 };
@@ -69,6 +73,7 @@ export function CalendarPresets({
   theme,
   scheme,
 }: CalendarPresetsProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
   const { applyPreset, clear } = useCalendarActions();
@@ -128,10 +133,10 @@ export function CalendarPresets({
     <div
       data-dateforge-presets=""
       data-area="presets"
-      data-theme={theme}
+      data-theme={dataTheme}
       data-scheme={scheme}
       className={[styles.container, className].filter(Boolean).join(" ")}
-      style={gridSlot}
+      style={{ ...themeStyle, ...gridSlot }}
     >
       <div
         ref={containerRef}

--- a/src/modules/selected-dates/CalendarSelectedDates.tsx
+++ b/src/modules/selected-dates/CalendarSelectedDates.tsx
@@ -5,6 +5,7 @@ import { dateKey } from "../../core/calendar-date";
 import { fromCalendarDateTime } from "../../core/timezone-boundary";
 import { ClearIcon } from "../../react/icons";
 import { useLabels } from "../../react/labels-context";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { UIButton } from "../../react/ui/button";
 import { useStoreSelector } from "../../react/use-store-selector";
@@ -35,8 +36,11 @@ export type CalendarSelectedDatesProps = {
   removeRangeEndLabel?: string;
   col?: number | string;
   className?: string;
-  /** Per-module theme override (`data-theme` on the module container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the module container). */
   scheme?: "light" | "dark" | "auto";
 };
@@ -137,6 +141,7 @@ export function CalendarSelectedDates({
   theme,
   scheme,
 }: CalendarSelectedDatesProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
   const t = useLabels();
@@ -177,10 +182,10 @@ export function CalendarSelectedDates({
       <div
         data-dateforge-selected-dates=""
         data-area="selected-dates"
-        data-theme={theme}
+        data-theme={dataTheme}
         data-scheme={scheme}
         className={[styles.container, className].filter(Boolean).join(" ")}
-        style={gridSlot}
+        style={{ ...themeStyle, ...gridSlot }}
       >
         {(expanded ? selection.dates : selection.dates.slice(0, cap)).map(
           (dt) => {
@@ -250,7 +255,7 @@ export function CalendarSelectedDates({
       data-dateforge-selected-dates=""
       data-area="selected-dates"
       className={[styles.container, className].filter(Boolean).join(" ")}
-      style={gridSlot}
+      style={{ ...themeStyle, ...gridSlot }}
     >
       {ranges.map((range, index) => {
         const { start, end } = range;

--- a/src/modules/time/CalendarTimeWheel.tsx
+++ b/src/modules/time/CalendarTimeWheel.tsx
@@ -9,6 +9,7 @@ import { resolveDefaultTime } from "../../core/state";
 import { toCalendarDateTime } from "../../core/timezone-boundary";
 import { useToday } from "../../hooks/use-today";
 import { useLabels } from "../../react/labels-context";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import { useTimePickerDraft } from "../../react/picker-draft";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { UIButton } from "../../react/ui/button";
@@ -51,8 +52,11 @@ export type CalendarTimeWheelProps = {
   secondsLabel?: string;
   timePeriodLabel?: string;
   timePickerLabel?: string;
-  /** Per-module theme override (`data-theme` on the module container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the module container). */
   scheme?: "light" | "dark" | "auto";
   col?: number | string;
@@ -86,6 +90,7 @@ export function CalendarTimeWheel({
   className,
   onTimeSelect,
 }: CalendarTimeWheelProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
   const t = useLabels();
@@ -221,10 +226,10 @@ export function CalendarTimeWheel({
       data-dateforge-time=""
       data-area="time"
       data-readonly={readOnly || undefined}
-      data-theme={theme}
+      data-theme={dataTheme}
       data-scheme={scheme}
       className={[styles.container, className].filter(Boolean).join(" ")}
-      style={gridSlot}
+      style={{ ...themeStyle, ...gridSlot }}
     >
       {headerText && (
         <div className={styles.boundedDate} data-bound={bound}>

--- a/src/modules/toolbar/CalendarToolbar.tsx
+++ b/src/modules/toolbar/CalendarToolbar.tsx
@@ -46,6 +46,7 @@ import {
   ThemeToggleIcon,
 } from "../../react/icons";
 import { useLabels } from "../../react/labels-context";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import {
   PickerDraftProvider,
   TimePickerDraftProvider,
@@ -153,8 +154,11 @@ export type CalendarToolbarProps = WithClass & {
    * overrides this (e.g. a from-label and to-label in one toolbar).
    */
   bound?: Bound;
-  /** Per-module theme override (`data-theme` on the container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the container). */
   scheme?: "light" | "dark" | "auto";
 };
@@ -205,6 +209,7 @@ export function CalendarToolbar({
   className,
   children,
 }: CalendarToolbarProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const t = useLabels();
   const ctx = useMemo(() => ({ offset, bound }), [offset, bound]);
   const gridTemplateColumns =
@@ -220,10 +225,11 @@ export function CalendarToolbar({
         aria-label={t("calendarNavigation", undefined, label)}
         data-dateforge-toolbar=""
         data-cols={cols !== undefined ? "" : undefined}
-        data-theme={theme}
+        data-theme={dataTheme}
         data-scheme={scheme}
         className={cx(styles.toolbar, className)}
         style={{
+          ...themeStyle,
           ...getGridSlotStyle(col),
           ...(gridTemplateColumns ? { gridTemplateColumns } : undefined),
           ...(justify ? { justifyContent: justify } : undefined),

--- a/src/modules/years-grid/CalendarYearsGrid.tsx
+++ b/src/modules/years-grid/CalendarYearsGrid.tsx
@@ -6,6 +6,7 @@ import { usePageSlide } from "../../hooks/use-page-slide";
 import { useRovingTileFocus } from "../../hooks/use-roving-tile-focus";
 import { ChevronLeftIcon, ChevronRightIcon } from "../../react/icons";
 import { useLabels } from "../../react/labels-context";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { UIButton } from "../../react/ui/button";
 import { UITile } from "../../react/ui/tile";
@@ -31,8 +32,11 @@ export type CalendarYearsGridProps = {
   outOfRangeBehavior?: OutOfRangeBehavior;
   col?: number | string;
   className?: string;
-  /** Per-module theme override (`data-theme` on the module container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the module container). */
   scheme?: "light" | "dark" | "auto";
   onYearSelect?: (year: number) => void;
@@ -71,6 +75,7 @@ export function CalendarYearsGrid({
   scheme,
   onYearSelect,
 }: CalendarYearsGridProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
   const t = useLabels();
@@ -179,10 +184,10 @@ export function CalendarYearsGrid({
     <div
       data-dateforge-years-grid=""
       data-area="years"
-      data-theme={theme}
+      data-theme={dataTheme}
       data-scheme={scheme}
       className={[styles.container, className].filter(Boolean).join(" ")}
-      style={gridSlot}
+      style={{ ...themeStyle, ...gridSlot }}
     >
       {showControls && (
         <div

--- a/src/modules/years-track/CalendarYearsTrack.tsx
+++ b/src/modules/years-track/CalendarYearsTrack.tsx
@@ -1,6 +1,7 @@
 import { boundDateOf } from "../../core/bound";
 import { calendarDate, daysInMonth } from "../../core/calendar-date";
 import { useLabels } from "../../react/labels-context";
+import type { ModuleTheme } from "../../react/module-theme";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { useStoreSelector } from "../../react/use-store-selector";
 import { VirtualTrack } from "../../react/VirtualTrack";
@@ -13,8 +14,11 @@ export type CalendarYearsTrackProps = {
   bound?: "from" | "to";
   col?: number | string;
   className?: string;
-  /** Per-module theme override (`data-theme` on the track). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the track).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the track). */
   scheme?: "light" | "dark" | "auto";
   onYearSelect?: (year: number) => void;

--- a/src/modules/years-wheel/CalendarYearsWheel.tsx
+++ b/src/modules/years-wheel/CalendarYearsWheel.tsx
@@ -4,6 +4,7 @@ import { calendarDate, daysInMonth } from "../../core/calendar-date";
 import { toCalendarDateTime } from "../../core/timezone-boundary";
 import { useToday } from "../../hooks/use-today";
 import { useLabels } from "../../react/labels-context";
+import { type ModuleTheme, useModuleTheme } from "../../react/module-theme";
 import { usePickerDraft } from "../../react/picker-draft";
 import { useCalendarActions, useCalendarStore } from "../../react/provider";
 import { UIButton } from "../../react/ui/button";
@@ -57,8 +58,11 @@ export type CalendarYearsWheelProps = {
    * drum (v2 parity). Hidden while the range is empty. Default `true`.
    */
   showBoundDate?: boolean;
-  /** Per-module theme override (`data-theme` on the module container). */
-  theme?: string;
+  /**
+   * Per-module theme override: a built-in family name (`data-theme`) or a
+   * `createTheme` token object (inline `--c-*` vars on the container).
+   */
+  theme?: ModuleTheme;
   /** Per-module scheme override (`data-scheme` on the module container). */
   scheme?: "light" | "dark" | "auto";
   col?: number | string;
@@ -82,6 +86,7 @@ export function CalendarYearsWheel({
   className,
   onYearSelect,
 }: CalendarYearsWheelProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
   const t = useLabels();
@@ -161,10 +166,10 @@ export function CalendarYearsWheel({
     <div
       data-dateforge-years-wheel=""
       data-area="years-wheel"
-      data-theme={theme}
+      data-theme={dataTheme}
       data-scheme={scheme}
       className={[styles.container, className].filter(Boolean).join(" ")}
-      style={gridSlot}
+      style={{ ...themeStyle, ...gridSlot }}
     >
       {headerText && (
         <div className={styles.boundedDate} data-bound={bound}>

--- a/src/react/VirtualTrack.tsx
+++ b/src/react/VirtualTrack.tsx
@@ -8,6 +8,7 @@ import {
 import { useItemSize } from "../hooks/use-item-size";
 import { useTrack } from "../hooks/use-track";
 import { getGridSlotStyle } from "../utils/get-grid-slot-style";
+import { type ModuleTheme, useModuleTheme } from "./module-theme";
 import styles from "./virtual-track.module.css";
 
 /**
@@ -48,7 +49,8 @@ export type VirtualTrackProps = {
   getAriaValueMax: (idx: number) => number;
   getAriaValueText: (idx: number) => string;
   col?: number | string;
-  theme?: string;
+  /** Built-in family name, or a `createTheme` token object. */
+  theme?: ModuleTheme;
   scheme?: "light" | "dark" | "auto";
   className?: string;
   /** Extra container style — e.g. a wider `--cal-size-track-item`. */
@@ -113,6 +115,7 @@ export function VirtualTrack({
   renderItem,
   renderOverlay,
 }: VirtualTrackProps) {
+  const { dataTheme, themeStyle } = useModuleTheme(theme);
   const containerRef = useRef<HTMLDivElement>(null);
   const itemWidth = useItemSize(containerRef, "width", initialItemWidth);
 
@@ -207,7 +210,7 @@ export function VirtualTrack({
   return (
     <div
       data-area={dataArea}
-      data-theme={theme}
+      data-theme={dataTheme}
       data-scheme={scheme}
       ref={ref}
       className={cx(styles.container, className)}
@@ -223,7 +226,7 @@ export function VirtualTrack({
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerCancel}
-      style={{ ...getGridSlotStyle(col), ...style }}
+      style={{ ...themeStyle, ...getGridSlotStyle(col), ...style }}
     >
       <div className={styles.highlight} aria-hidden />
       {renderOverlay?.({ activeIndex })}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -95,3 +95,5 @@ export {
   type CalendarConfigOptions,
   createCalendarConfig,
 } from "./config";
+// The union every module's `theme` prop takes (name or `createTheme` object).
+export type { ModuleTheme } from "./module-theme";

--- a/src/react/module-theme.ts
+++ b/src/react/module-theme.ts
@@ -1,0 +1,38 @@
+import { type CSSProperties, useMemo } from "react";
+import type { ThemeFamily } from "../styles/theme-tokens";
+import { resolveThemeScope } from "./theme-scope";
+
+/**
+ * Per-module theme override: a built-in family name (rides on `data-theme`,
+ * resolved by the generated `cal-themes` CSS) or a `createTheme` token object
+ * (applied as inline `--c-*` vars, so it needs no generated stylesheet).
+ *
+ * Same union as the root `Calendar theme` prop — a module can therefore be
+ * handed the very object the root uses, or a different one to stand out.
+ */
+export type ModuleTheme = string | ThemeFamily;
+
+export type ResolvedModuleTheme = {
+  /** `data-theme` value — set only for built-in names. */
+  dataTheme?: string;
+  /** Inline `--c-*` vars — set only for `createTheme` objects. */
+  themeStyle?: CSSProperties;
+};
+
+const NONE: ResolvedModuleTheme = Object.freeze({});
+
+/**
+ * Resolve a module's `theme` prop into what its container needs to render.
+ * Token objects produce `light-dark()` vars, so a custom family flips with the
+ * active `color-scheme` exactly like a built-in — no JS mode tracking.
+ *
+ * Spread `themeStyle` FIRST in the container's `style` so the module's own
+ * layout vars (grid slot, strip offsets) always win over theme colors.
+ */
+export function useModuleTheme(theme?: ModuleTheme): ResolvedModuleTheme {
+  return useMemo(() => {
+    if (theme === undefined) return NONE;
+    const { dataTheme, style } = resolveThemeScope(theme);
+    return { dataTheme, themeStyle: style as CSSProperties | undefined };
+  }, [theme]);
+}

--- a/src/styles/layers.css
+++ b/src/styles/layers.css
@@ -51,6 +51,38 @@
     color-scheme: dark;
   }
 
+  /* Per-module `scheme` — the same narrowing, one level in. Without this the
+     attribute rendered but painted nothing: every module theme (built-in name
+     or a createTheme object) resolves its colors through light-dark(), which
+     reads the nearest color-scheme, and only the root/popup declared one. */
+  [data-dateforge-root] [data-scheme="light"],
+  [data-dateforge-popup] [data-scheme="light"] {
+    color-scheme: light;
+  }
+  [data-dateforge-root] [data-scheme="dark"],
+  [data-dateforge-popup] [data-scheme="dark"] {
+    color-scheme: dark;
+  }
+  /* `auto` on a module means "follow the root" — re-open both sides so a module
+     inside a forced-scheme root can opt back out to the OS preference. */
+  [data-dateforge-root] [data-scheme="auto"],
+  [data-dateforge-popup] [data-scheme="auto"] {
+    color-scheme: light dark;
+  }
+
+  /* A module that declares its OWN theme or scheme becomes its own painted
+     surface. Without a backdrop of its own, a dark-schemed module paints light
+     ink straight onto the root's light backdrop (unreadable, and an axe
+     contrast failure). Modules stay transparent by default — this only arms
+     when `theme`/`scheme` is set on the module. */
+  [data-dateforge-root] [data-theme],
+  [data-dateforge-root] [data-scheme],
+  [data-dateforge-popup] [data-theme],
+  [data-dateforge-popup] [data-scheme] {
+    background: var(--c-backdrop);
+    color: var(--c-text);
+  }
+
   /* Root shell only. */
   [data-dateforge-root] {
     container-type: inline-size;


### PR DESCRIPTION
## Summary

<!-- What changed and why -->

## Checklist

- [x] `npm run verify` passes locally
- [x] Changeset added (`npx changeset`) — or labelled `skip-changeset`
- [x] New/updated tests for changed behaviour
- [x] a11y: no new axe violations (`npm run test -- --reporter=verbose src/__tests__/a11y`)
- [ ] Public API changes documented in JSDoc / README
