### PR TITLE
fix: month selector update

### DIFF
--- a/.changeset/preset-nav-toolbar-width.md
+++ b/.changeset/preset-nav-toolbar-width.md
@@ -1,0 +1,10 @@
+---
+"@dateforge/react-calendar": patch
+---
+
+Fix preset navigation and toolbar width jitter.
+
+- **Presets move the view**: clicking a preset committed the value but left the grid on the month you were already on — the selection landed off-screen. It now navigates to the preset's first date.
+- **Month trigger keeps one width**: `CalendarToolbarMonthTrigger` reserved no width at all, so a long month name ("September") resized the button and shoved the rest of the toolbar sideways. Both name variants now reserve their own widest month. The labels' sizers moved off the longest-by-character-count heuristic (character count is not width — every English short month is 3 chars, yet "May" renders wider than "Jan") and their text rides in CSS `content`, so it stays out of `textContent`, DOM queries and the a11y tree.
+- Toolbar month text no longer clips descenders (the y in "May", g in "Aug").
+- Thinner default toolbar button border (`0.5px`); named appearances that set `--cal-control-border` are unchanged.

--- a/src/__tests__/react/calendar-days-keyboard.test.tsx
+++ b/src/__tests__/react/calendar-days-keyboard.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, within } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { calendarDate } from "@/core/calendar-date";
 import { MIDNIGHT } from "@/core/calendar-time";
 import { compileDateRules } from "@/core/date-rule-engine";
@@ -53,13 +53,25 @@ function dayCell(container: HTMLElement, day: number) {
 }
 
 describe("CalendarDays keyboard", () => {
+  // The roving default is "explicit focus, else today-in-view, else the 1st"
+  // (CalendarDays), so these cases only hold while today sits OUTSIDE the
+  // Sept 2026 view — pin the clock instead of inheriting the machine's date
+  // (they started failing for real once the wall clock reached Sept 2026).
+  beforeAll(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(2026, 5, 15));
+  });
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
   it("gives exactly one cell tabindex=0 (roving), defaulting to the 1st", () => {
     const { container } = setup(config("day", "single"));
     const focusable = within(container)
       .getAllByRole("gridcell")
       .filter((c) => c.getAttribute("tabindex") === "0");
     expect(focusable).toHaveLength(1);
-    // No selection, today (2026-06) not in the Sept 2026 view -> 1st of month.
+    // No selection, pinned today (2026-06) not in the Sept 2026 view -> 1st.
     expect(focusable[0].textContent).toBe("1");
   });
 

--- a/src/__tests__/react/toolbar.test.tsx
+++ b/src/__tests__/react/toolbar.test.tsx
@@ -74,8 +74,15 @@ describe("Toolbar primitives", () => {
     const label = container.querySelector("[data-toolbar-label]");
     expect(label?.getAttribute("role")).toBe("heading");
     expect(label?.getAttribute("aria-level")).toBe("3");
-    // Invisible sizer holds September (longest en-US month) at the same year.
-    expect(label?.textContent).toContain("September 2026");
+    // Invisible sizers reserve EVERY month's width at the same year, and carry
+    // their text in CSS `content` (`--sizer-text`) — never as a text node, so
+    // they stay out of textContent, queries and the a11y tree.
+    const sizers = [...label!.querySelectorAll("[aria-hidden='true'][style]")]
+      .map((el) => el.getAttribute("style"))
+      .join("");
+    expect(sizers).toContain('"September 2026"');
+    expect(sizers).toContain('"May 2026"');
+    expect(label?.textContent).not.toContain("September");
     expect(getByText("June 2026")).toBeTruthy();
   });
 
@@ -260,7 +267,9 @@ describe("Toolbar primitives", () => {
     expect(getByText("2026")).toBeTruthy();
     const month = container.querySelector("[data-toolbar-month-label]");
     expect(month?.textContent).toContain("Current month, June");
-    expect(month?.textContent).toContain("September"); // width sizer
+    // Width sizers live in CSS `content`, so the label reads only its own month.
+    expect(month?.textContent).not.toContain("September");
+    expect(month?.innerHTML).toContain("September");
     const year = container.querySelector("[data-toolbar-year-label]");
     expect(year?.textContent).toContain("Current year, 2026");
   });
@@ -376,6 +385,22 @@ describe("Toolbar month/year triggers", () => {
     expect(btn.textContent).toContain("Jun");
     expect(btn.getAttribute("aria-expanded")).toBe("false");
     expect(queryByRole("dialog")).toBeNull();
+  });
+
+  it("month trigger reserves every month's width per variant", () => {
+    const { getByLabelText } = setup(<CalendarToolbarMonthTrigger />);
+    const btn = getByLabelText("Change month, currently June");
+    // Both variants carry their OWN sizer stack, so the trigger keeps one width
+    // all year (a `display: none` variant reserves nothing for the other) and
+    // the toolbar never reflows when the month name gets longer.
+    const sizers = [...btn.querySelectorAll("[aria-hidden='true'][style]")]
+      .map((el) => el.getAttribute("style"))
+      .join("");
+    for (const name of ["January", "September", "May", "Jan", "Sep", "May"]) {
+      expect(sizers).toContain(`"${name}"`);
+    }
+    // Sizer text lives in CSS `content`, never in the button's own text.
+    expect(btn.textContent).toBe("JuneJun");
   });
 
   it("short prop forces the short month name (data-short)", () => {

--- a/src/modules/presets/CalendarPresets.tsx
+++ b/src/modules/presets/CalendarPresets.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef } from "react";
-import { dateKey } from "../../core/calendar-date";
+import { type CalendarDate, dateKey } from "../../core/calendar-date";
 import {
   compilePresets,
   definePreset,
@@ -47,6 +47,13 @@ function isPresetActive(
   return false;
 }
 
+/** View anchor for a resolved preset — the date the grid should jump to. */
+function presetAnchor(result: PresetResult): CalendarDate {
+  if (result.kind === "date") return result.date;
+  if (result.kind === "dates") return result.dates[0];
+  return result.range.start;
+}
+
 export type CalendarPresetsProps = {
   /**
    * Presets to render. Accepts the declarative form ({@link PresetInput}:
@@ -76,7 +83,7 @@ export function CalendarPresets({
   const { dataTheme, themeStyle } = useModuleTheme(theme);
   const store = useCalendarStore();
   const config = store.getConfig();
-  const { applyPreset, clear } = useCalendarActions();
+  const { applyPreset, navigateTo, clear } = useCalendarActions();
 
   const selection = useStoreSelector(store, (s) => s.selection);
 
@@ -166,6 +173,7 @@ export function CalendarPresets({
                   clear();
                 } else {
                   applyPreset(ep.result);
+                  navigateTo(presetAnchor(ep.result));
                 }
               }}
             >

--- a/src/modules/toolbar/CalendarToolbar.tsx
+++ b/src/modules/toolbar/CalendarToolbar.tsx
@@ -532,13 +532,52 @@ function useViewText(
 }
 
 /**
+ * Width-stable text slot. Every candidate rendering stacks invisibly under the
+ * live one, so the box reserves the widest RENDERED width and stepping months
+ * never shifts the toolbar (CLS-free). Stacking beats picking the longest
+ * string by `length`: character count is not width — every English short month
+ * name is 3 chars, yet "May" is far wider than "Jan".
+ *
+ * Each sizer carries its text as a CSS `content` string, NOT as a text node:
+ * the box still sizes to it, but it lands in no `textContent`, no query
+ * (`getByText`) and no accessibility tree. A browser that can't substitute
+ * `var()` into `content` just renders nothing — the width stops being
+ * reserved, nothing breaks.
+ */
+function WidthStableText({
+  candidates,
+  children,
+}: {
+  candidates: string[];
+  children: ReactNode;
+}) {
+  return (
+    <span className={styles.slot}>
+      {candidates.map((c, i) => (
+        <span
+          // Index key: a fixed-length positional set (the 12 months), and a
+          // locale may repeat a rendering — a value key would collide.
+          key={i}
+          className={styles.sizer}
+          aria-hidden="true"
+          // JSON quoting is CSS string quoting for this alphabet (quotes and
+          // backslashes escaped; month names carry no newlines).
+          style={{ "--sizer-text": JSON.stringify(c) } as CSSProperties}
+        />
+      ))}
+      <span>{children}</span>
+    </span>
+  );
+}
+
+/**
  * Live "Month Year" toolbar title. Rendered as a heading (`aria-level`,
  * default 2) so screen-reader users can jump to the calendar's anchor point.
  * Pass `children` for a freeform title instead of the live one.
  *
- * Width-stable: an invisible sizer holds the year's longest formatted value
- * (same Intl options), so stepping from "May" to "September" never shifts the
- * arrows around the label.
+ * Width-stable: invisible sizers hold every month's formatted value for the
+ * displayed year (same Intl options), so stepping from "May" to "September"
+ * never shifts the arrows around the label.
  */
 export function CalendarToolbarLabel({
   options,
@@ -553,17 +592,14 @@ export function CalendarToolbarLabel({
   const locale = store.getConfig().locale;
   const opts = options ?? FULL_LABEL;
   const { date, text } = useViewText(opts, offset, bound);
-  // Longest of the 12 month renderings for the displayed year/day — covers the
-  // month-name variance that dominates the width (day digits vary by at most
-  // one character and only in day-bearing formats).
-  const sizer = useMemo(() => {
+  // All 12 month renderings for the displayed year/day — covers the month-name
+  // variance that dominates the width (day digits vary by at most one
+  // character and only in day-bearing formats).
+  const sizers = useMemo(() => {
     const fmt = new Intl.DateTimeFormat(locale, opts);
-    let longest = "";
-    for (let m = 0; m < 12; m++) {
-      const s = fmt.format(new Date(date.year, m, date.day));
-      if (s.length > longest.length) longest = s;
-    }
-    return longest;
+    return Array.from({ length: 12 }, (_, m) =>
+      fmt.format(new Date(date.year, m, date.day)),
+    );
   }, [locale, opts, date.year, date.day]);
   return (
     <span
@@ -574,12 +610,7 @@ export function CalendarToolbarLabel({
       style={getGridSlotStyle(col)}
     >
       {children ?? (
-        <span className={styles.slot}>
-          <span className={styles.sizer} aria-hidden="true">
-            {sizer}
-          </span>
-          <span>{text}</span>
-        </span>
+        <WidthStableText candidates={sizers}>{text}</WidthStableText>
       )}
     </span>
   );
@@ -594,9 +625,6 @@ function monthNames(
   const fmt = new Intl.DateTimeFormat(locale, { month: format });
   return Array.from({ length: 12 }, (_, i) => fmt.format(new Date(2021, i, 1)));
 }
-
-const longest = (names: string[]) =>
-  names.reduce((a, b) => (b.length > a.length ? b : a), "");
 
 /**
  * Month-only label. Reserves the width of the locale's longest month name (the
@@ -623,10 +651,7 @@ export function CalendarToolbarMonthLabel({
     offset,
     bound,
   );
-  const sizer = useMemo(
-    () => longest(monthNames(locale, format)),
-    [locale, format],
-  );
+  const sizers = useMemo(() => monthNames(locale, format), [locale, format]);
   const longName = useMemo(
     () =>
       new Intl.DateTimeFormat(locale, { month: "long" }).format(
@@ -643,9 +668,8 @@ export function CalendarToolbarMonthLabel({
       <span className={styles.srOnly}>
         {t("currentMonth", { month: longName })}
       </span>
-      <span className={styles.slot} aria-hidden="true">
-        <span className={styles.sizer}>{sizer}</span>
-        <span>{text}</span>
+      <span aria-hidden="true">
+        <WidthStableText candidates={sizers}>{text}</WidthStableText>
       </span>
     </span>
   );
@@ -896,9 +920,15 @@ export function CalendarToolbarMonthTrigger({
         {/* Long + short month both render; CSS shows one (forced by the `short`
             prop or auto-swapped by a narrow toolbar container, v2 parity). The
             accessible name is the aria-label above, so the hidden variant adds
-            no SR noise. */}
-        <span className={styles.variantLong}>{longText}</span>
-        <span className={styles.variantShort}>{shortText}</span>
+            no SR noise. Each variant reserves its OWN widest month, so the
+            trigger keeps one width all year and the toolbar never reflows
+            around it (a `display:none` variant reserves nothing). */}
+        <span className={styles.variantLong}>
+          <WidthStableText candidates={longNames}>{longText}</WidthStableText>
+        </span>
+        <span className={styles.variantShort}>
+          <WidthStableText candidates={names}>{shortText}</WidthStableText>
+        </span>
       </UIButton>
       <CalendarPopup
         open={open}

--- a/src/modules/toolbar/toolbar.module.css
+++ b/src/modules/toolbar/toolbar.module.css
@@ -110,8 +110,9 @@
     font-weight: 500;
   }
 
-  /* Month label width sizer: the longest month name sits invisible under the
-     live one, so stepping months never shifts the toolbar layout. */
+  /* Width sizer (labels AND month/year triggers): every candidate rendering
+     stacks invisible under the live one, so the box reserves the WIDEST
+     rendered width and stepping months never shifts the toolbar layout. */
   .slot {
     display: inline-grid;
     text-align: center;
@@ -124,10 +125,24 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    /* Descenders (the y in "May", g in "Aug") fall BELOW the line box, and a
+       `line-height: 1` host — every UIButton — would have `overflow: hidden`
+       shear them off. Overflow clips at the padding edge, so pad the clip box
+       and cancel it with an equal negative margin: descenders survive and the
+       outer height is unchanged. */
+    padding-block: 0.25em;
+    margin-block: -0.25em;
   }
 
+  /* The sizer's text rides in `content` (a `--sizer-text` string set inline),
+     so it reserves width without existing as a text node — invisible to
+     `textContent`, DOM queries and the a11y tree. */
   .sizer {
     visibility: hidden;
+  }
+
+  .sizer::before {
+    content: var(--sizer-text, "");
   }
 
   /* Grid cells are sized to content (`grid-auto-columns: max-content`), so every
@@ -137,8 +152,9 @@
 
   /* Long/short month variants (v2 parity): both render, the short pair is hidden
      by default. A `short` prop (`[data-short]`) or a narrow toolbar container
-     swaps to it; each regime reserves its OWN longest-month width via its sizer,
-     so stepping never shifts layout in either. */
+     swaps to it; each variant wraps its own `.slot` sizer stack, so it reserves
+     its OWN widest month and stepping never shifts layout in either regime (a
+     `display: none` variant reserves nothing, hence one stack per variant). */
   .variantShort {
     display: none;
   }

--- a/src/react/ui/button.module.css
+++ b/src/react/ui/button.module.css
@@ -23,7 +23,10 @@
     /* Shape/spacing are appearance-driven (fallbacks = the v3 default look, so
        "no appearance" is unchanged). */
     padding: var(--cal-control-padding, 0.3em 0.7em);
-    border: var(--cal-control-border, 1px) solid var(--c-stroke, #d0d3d9);
+    /* Hairline default: appearances that want a heavier edge set
+       `--cal-control-border` (press/square/zenith ship 1px). Halving only the
+       FALLBACK keeps every named appearance exactly as generated. */
+    border: var(--cal-control-border, 0.5px) solid var(--c-stroke, #d0d3d9);
     border-radius: var(--c-day-radius, 8px);
     background: transparent;
     color: var(--c-text, #222);


### PR DESCRIPTION
## Summary

<!-- What changed and why -->

## Checklist

- [ ] `npm run verify` passes locally
- [ ] Changeset added (`npx changeset`) — or labelled `skip-changeset`
- [ ] New/updated tests for changed behaviour
- [ ] a11y: no new axe violations (`npm run test -- --reporter=verbose src/__tests__/a11y`)
- [ ] Public API changes documented in JSDoc / README
