### PR TITLE
feat: update popup

### DIFF
--- a/.changeset/popup-inherits-theme-appearance.md
+++ b/.changeset/popup-inherits-theme-appearance.md
@@ -1,0 +1,14 @@
+---
+"@dateforge/react-calendar": patch
+---
+
+Fix month/year popups not following the calendar's theme and appearance.
+
+A portalled popup lives in `document.body`, so it inherits nothing from the root shell — and two things were missing there:
+
+- The **appearance bridge** (`--cal-*` → `--c-day-radius` / `--c-radius` / `--c-gap` / `--c-day-gap` / `--c-pad`) and the type stack were declared on `[data-dateforge-root]` only. Every module inside a picker fell back to its literal defaults, so radii, gaps and padding ignored the appearance and the font stack differed from the calendar's (the popup read a `--c-font` token nothing ever set). They now cover `[data-dateforge-popup]` too.
+- An appearance set on a **DOM ancestor** rather than the `appearance` prop never reached the popup at all, since theme-scope is a React context. The popup now copies the appearance contract off its anchor, which catches both routes; an explicit prop still wins.
+
+Default popup corner radius follows `--c-radius` (12px) instead of its own 10px fallback, matching the root.
+
+Guarded by the first play-function story (`Toolbar / PopupMatchesRootAppearance`) — it asserts the popup's computed shape vars equal the root's, and only means anything in the browser project, since happy-dom computes no cascade.

--- a/src/modules/toolbar/Toolbar.stories.tsx
+++ b/src/modules/toolbar/Toolbar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
 import { addMonths, calendarDate } from "@/core/calendar-date";
 import { MIDNIGHT } from "@/core/calendar-time";
 import { compileDateRules } from "@/core/date-rule-engine";
@@ -502,3 +503,77 @@ export const BoundSplit: Story = {
     </div>
   ),
 };
+
+/**
+ * Regression guard: a portalled popup must paint like the calendar it belongs
+ * to. It lives in `document.body`, so it inherits NOTHING from the root — the
+ * appearance contract reaches it only because `layers.css` bridges `--cal-*` →
+ * `--c-*` for `[data-dateforge-popup]` too, and because the popup copies the
+ * contract off its anchor (which covers an appearance set on a DOM ancestor,
+ * the way this Storybook's toolbar sets it).
+ *
+ * This assertion only means something in a REAL browser: happy-dom does not
+ * compute the cascade, so the shape vars would read empty on both sides and
+ * the test would pass while the bug shipped.
+ */
+export const PopupMatchesRootAppearance: Story = {
+  render: (_, ctx) => (
+    <div data-appearance="bubble">
+      <Frame
+        {...storyThemeProps(ctx.globals)}
+        globals={ctx.globals}
+        days={false}
+      >
+        <CalendarToolbar>
+          <CalendarToolbarMonthTrigger />
+          <CalendarToolbarYearTrigger />
+        </CalendarToolbar>
+      </Frame>
+    </div>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    const root = canvasElement.querySelector<HTMLElement>(
+      "[data-dateforge-root]",
+    );
+    if (!root) throw new Error("no calendar root");
+
+    // The shape vars a module actually consumes, plus the type stack.
+    const shapeOf = (el: HTMLElement) => {
+      const cs = getComputedStyle(el);
+      return {
+        dayRadius: cs.getPropertyValue("--c-day-radius").trim(),
+        radius: cs.getPropertyValue("--c-radius").trim(),
+        gap: cs.getPropertyValue("--c-gap").trim(),
+        pad: cs.getPropertyValue("--c-pad").trim(),
+        font: cs.fontFamily,
+      };
+    };
+
+    await step("month popup paints like the root", async () => {
+      await userEvent.click(canvas.getByLabelText(/change month/i));
+      const popup = await waitForPopup();
+      expect(shapeOf(popup)).toEqual(shapeOf(root));
+      // `bubble` really is in play — not both sides falling back together.
+      expect(shapeOf(popup).dayRadius).not.toBe("");
+      await userEvent.keyboard("{Escape}");
+    });
+
+    await step("year popup paints like the root", async () => {
+      await userEvent.click(canvas.getByLabelText(/change year/i));
+      const popup = await waitForPopup();
+      expect(shapeOf(popup)).toEqual(shapeOf(root));
+      await userEvent.keyboard("{Escape}");
+    });
+  },
+};
+
+/** The popup portals to `document.body`, so it is outside the story canvas. */
+async function waitForPopup(): Promise<HTMLElement> {
+  for (let i = 0; i < 50; i++) {
+    const el = document.querySelector<HTMLElement>("[data-dateforge-popup]");
+    if (el) return el;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  throw new Error("popup never opened");
+}

--- a/src/react/CalendarPopup.tsx
+++ b/src/react/CalendarPopup.tsx
@@ -6,7 +6,10 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
-import { resolveAppearance } from "../styles/appearance-tokens";
+import {
+  APPEARANCE_TOKEN_TO_VAR,
+  resolveAppearance,
+} from "../styles/appearance-tokens";
 import { resolveThemeScope, useThemeScope } from "./theme-scope";
 
 /**
@@ -17,7 +20,8 @@ import { resolveThemeScope, useThemeScope } from "./theme-scope";
  *
  * Closes on Escape and on a pointer-down outside both the popup and its anchor.
  * Re-declares `data-theme` / `data-scheme` (from theme-scope) so `--c-*` tokens
- * resolve even though it lives outside the root shell.
+ * resolve even though it lives outside the root shell, and copies the
+ * appearance contract off the anchor (see {@link useInheritedAppearance}).
  */
 export type CalendarPopupProps = {
   open: boolean;
@@ -35,6 +39,38 @@ const MARGIN = 8;
 
 const FOCUSABLE =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const APPEARANCE_VARS = Object.values(APPEARANCE_TOKEN_TO_VAR);
+
+/**
+ * The appearance contract (`--cal-*`) as the ANCHOR sees it.
+ *
+ * `data-appearance` / a custom appearance only reach the popup when they came
+ * through the `appearance` prop — theme-scope is a React context, so it knows
+ * nothing about an appearance set on a DOM ancestor (a wrapper div, an
+ * app-level shell, the Storybook toolbar). Custom properties reach the anchor
+ * by inheritance either way, so reading them there catches both routes; they
+ * ride as inline vars UNDER the resolved appearance, so an explicit prop still
+ * wins. Read on open — the popup is transient, and an appearance swap while one
+ * is open re-runs this anyway.
+ */
+function useInheritedAppearance(
+  open: boolean,
+  anchor: HTMLElement | null,
+): Record<string, string> {
+  const [vars, setVars] = useState<Record<string, string>>({});
+  useLayoutEffect(() => {
+    if (!open || !anchor) return;
+    const cs = getComputedStyle(anchor);
+    const next: Record<string, string> = {};
+    for (const v of APPEARANCE_VARS) {
+      const value = cs.getPropertyValue(v).trim();
+      if (value) next[v] = value;
+    }
+    setVars(next);
+  }, [open, anchor]);
+  return vars;
+}
 
 /**
  * Tabbable descendants in DOM order. The selector already drops `[disabled]` and
@@ -58,6 +94,7 @@ export function CalendarPopup({
   const { dataTheme, style: themeStyle } = resolveThemeScope(theme);
   const { dataAppearance, style: appearanceStyle } =
     resolveAppearance(appearance);
+  const inheritedAppearance = useInheritedAppearance(open, anchor);
   const [mounted, setMounted] = useState(false);
   const [pos, setPos] = useState<Pos | null>(null);
 
@@ -155,6 +192,7 @@ export function CalendarPopup({
       data-scheme={scheme}
       data-placement={pos?.placement}
       style={{
+        ...inheritedAppearance,
         ...themeStyle,
         ...appearanceStyle,
         position: "fixed",

--- a/src/styles/layers.css
+++ b/src/styles/layers.css
@@ -39,7 +39,41 @@
     color-scheme: light dark;
     box-sizing: border-box;
     color: var(--c-text);
-    font-family: var(--c-font, system-ui, -apple-system, sans-serif);
+
+    /* Appearance bridge: the shape vars the modules consume alias the
+       appearance contract vars (set by `data-appearance` / a custom appearance
+       in cal-appearances), falling back to the v3 defaults. So "no appearance"
+       is the current v3 look, and an appearance overrides shape/spacing without
+       touching any module.
+       This MUST cover the popup too: a portalled popup lives in document.body
+       and inherits nothing from the root, so with a root-only bridge every
+       module inside a picker fell back to its literal defaults and the
+       appearance visibly stopped at the popup's edge. */
+    --c-day-radius: var(--cal-radius, 8px);
+    --c-radius: var(--cal-container-radius, 12px);
+    --c-gap: var(--cal-container-gap, 8px);
+    --c-day-gap: var(--cal-days-gap, 2px);
+    --c-pad: var(--cal-spacing, 12px);
+
+    /* Type travels with the shape, for the same reason. A modern
+       cross-platform system stack is the default (an appearance can override
+       via --cal-font). `ui-sans-serif`/`system-ui` pick the native UI face on
+       each OS; the rest are fallbacks for older engines. */
+    font-family: var(
+      --cal-font,
+      ui-sans-serif,
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      Roboto,
+      Helvetica,
+      Arial,
+      "Apple Color Emoji",
+      "Segoe UI Emoji",
+      sans-serif
+    );
+    letter-spacing: var(--cal-letter-spacing, normal);
   }
 
   [data-dateforge-root][data-scheme="light"],
@@ -83,37 +117,11 @@
     color: var(--c-text);
   }
 
-  /* Root shell only. */
+  /* Root shell only — the bridge and the type stack are shared with the popup
+     above, so only real shell layout stays here. */
   [data-dateforge-root] {
     container-type: inline-size;
     container-name: cal-root;
-    /* Appearance bridge: the shape vars the modules consume alias the
-       appearance contract vars (set by `data-appearance` / a custom appearance
-       in cal-appearances), falling back to the v3 defaults. So "no appearance"
-       is the current v3 look, and an appearance overrides shape/spacing without
-       touching any module. */
-    --c-day-radius: var(--cal-radius, 8px);
-    --c-radius: var(--cal-container-radius, 12px);
-    --c-gap: var(--cal-container-gap, 8px);
-    --c-day-gap: var(--cal-days-gap, 2px);
-    --c-pad: var(--cal-spacing, 12px);
-    /* A modern cross-platform system stack is the default (an appearance can
-       override via --cal-font). `ui-sans-serif`/`system-ui` pick the native UI
-       face on each OS; the rest are fallbacks for older engines. */
-    font-family: var(
-      --cal-font,
-      ui-sans-serif,
-      system-ui,
-      -apple-system,
-      BlinkMacSystemFont,
-      "Segoe UI",
-      Roboto,
-      Helvetica,
-      Arial,
-      "Apple Color Emoji",
-      "Segoe UI Emoji",
-      sans-serif
-    );
     display: grid;
     gap: var(--c-gap, 8px);
     inline-size: 100%;
@@ -121,7 +129,6 @@
        is deliberately NOT applied to the root — inflating the base font blew up
        the toolbar (gigantic label/time, the next button overflowed). Type scale
        is opt-in per surface (e.g. day numbers via `--cal-text-day`). */
-    letter-spacing: var(--cal-letter-spacing, normal);
     padding: var(--c-pad, 12px);
     border: var(--cal-border, 1px) solid var(--c-stroke);
     border-radius: var(--c-radius, 12px);


### PR DESCRIPTION
## Summary

<!-- What changed and why -->

## Checklist

- [ ] `npm run verify` passes locally
- [ ] Changeset added (`npx changeset`) — or labelled `skip-changeset`
- [ ] New/updated tests for changed behaviour
- [ ] a11y: no new axe violations (`npm run test -- --reporter=verbose src/__tests__/a11y`)
- [ ] Public API changes documented in JSDoc / README
